### PR TITLE
Move promoted box to its own directory and theme promoted box on mobile

### DIFF
--- a/src/components/components/opportunities-member/opportunities-member.js
+++ b/src/components/components/opportunities-member/opportunities-member.js
@@ -15,52 +15,52 @@ import React from 'react';
 import MemberUpdates from './../member-updates/member-updates';
 import MemberTools from './../member-tools/member-tools';
 import MemberTrainingResources from './../member-training-resources/member-training-resources';
+import PromotedBox from './../promoted-box/promoted-box';
 import LayoutContained from './../../layouts/layout-contained/layout-contained';
+import Layout2Col from './../../layouts/layout-2col/layout-2col';
 
 // styles
 import './opportunities-member.scss';
 
 // A simple wrapper for the upper section i.e. the title, description and propmoted box.
 // UpperSection is the place holder for
-const UpperSection = (props) =>  {
+const UpperSection = props => {
   return (
     <LayoutContained>
       <h1 className="title title--m-small opportunities-member__title">
         Opportunities
       </h1>
 
-      <div className="opportunities-member__info">
-        <p  className="opportunities-member__text highlighted-text highlighted-text--intense">
-          We bring you the best opportunities to contribute code. Practice your skills by taking part in compelling Open Source projects that match your interests!
-        </p>
-        <div className="promoted-box">
-            <h3 className="promoted-box__title"> Next steps after signing up </h3>
-          <ol className="promoted-box__content">
-            <li className="promoted-box__item"> Explore contribution opportunities </li>
-            <li className="promoted-box__item"> Reach out to  us </li>
-            <li className="promoted-box__item"> Explore available interships/jobs </li>
-            <li className="promoted-box__item"> Check the latest announcements </li>
-          </ol>
+      <Layout2Col
+        verticalGutters
+        horizontalGutters
+        className="opportunities-member__info"
+      >
+        <div>
+          <p className="opportunities-member__text highlighted-text">
+            We bring you the best opportunities to contribute code. Practice
+            your skills by taking part in compelling Open Source projects that
+            match your interests!
+          </p>
         </div>
-      </div>
+        <div className="promoted-box__wrapper">
+          <PromotedBox />
+        </div>
+      </Layout2Col>
     </LayoutContained>
   );
-}
+};
 
-
-export default (props) => {
-
+export default props => {
   // placeholder for the UpperSection compoenent.
-  const upperSection = props.skipTitle
-    ? ''
-    : <UpperSection />;
+  const upperSection = props.skipTitle ? '' : <UpperSection />;
 
   return (
     <div className="opportunities-member">
       {upperSection}
       <MemberUpdates announcements={props.announcements} jobs={props.jobs} />
       <MemberTools channels={props.channels} tools={props.tools} />
-      <MemberTrainingResources resources={props.resources}/>
+      <MemberTrainingResources resources={props.resources} />
     </div>
   );
-}
+};

--- a/src/components/components/opportunities-member/opportunities-member.scss
+++ b/src/components/components/opportunities-member/opportunities-member.scss
@@ -10,6 +10,7 @@
     display: inline-block;
     max-width: 730px;
     padding-right: 30px;
+    margin-top: 0;
   }
 
   &__info {

--- a/src/components/components/promoted-box/promoted-box.js
+++ b/src/components/components/promoted-box/promoted-box.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default props => {
+  return (
+    <div className="promoted-box">
+      <h3 className="promoted-box__title"> Next steps after signing up </h3>
+      <ol className="promoted-box__content">
+        <li className="promoted-box__item">
+          {' '}
+          Explore contribution opportunities{' '}
+        </li>
+        <li className="promoted-box__item"> Reach out to us </li>
+        <li className="promoted-box__item">
+          {' '}
+          Explore available interships/jobs{' '}
+        </li>
+        <li className="promoted-box__item"> Check the latest announcements </li>
+      </ol>
+    </div>
+  );
+};

--- a/src/components/components/promoted-box/promoted-box.scss
+++ b/src/components/components/promoted-box/promoted-box.scss
@@ -5,6 +5,15 @@
   background-color: color('light-green');
   display: inline-block;
 
+  &__wrapper {
+    display: flex;
+    justify-content: center;
+
+    @include breakpoint($tablet) {
+      justify-content: flex-end;
+    }
+  }
+
   &__title {
     @include font-size(20px);
     @include line-height(27px);
@@ -33,62 +42,21 @@
       font-size: 16px;
       line-height: 20px;
       font-weight: 800;
-      border: 2px solid color('light-navy');
-      border-radius: 100%;
       width: 25px;
       height: 25px;
       display: inline-block;
       text-align: center;
       vertical-align: middle;
-      margin-right: 5px;
-      box-sizing: border-box;
-      opacity: .3;
-
     }
 
-    &::after {
-      content: '';
-      box-sizing: border-box;
-      position: absolute;
-      width: 25px;
-      height: 25px;
-      background-color: color('light-navy');
-      border-radius: 100%;
-      opacity: 0.1;
-      top: 0;
-      left: 0;
+    @include breakpoint($mobile) {
 
-    }
-
-    &:nth-child(1) {
-      &::after {
-        top: 1px;
-        left: 4px;
+      &:nth-child(2) {
+        @include margin-left(45px);
       }
-    }
 
-    &:nth-child(2) {
-      @include margin-left(45px);
-
-      &::after {
-        top: 2px;
-        left: -2px;
-      }
-    }
-
-    &:nth-child(3) {
-      &::after {
-        top: 0px;
-        left: 3px;
-      }
-    }
-
-    &:nth-child(4) {
-      @include margin-left(25px);
-      
-      &::after {
-        top: -1px;
-        left: -3px;
+      &:nth-child(4) {
+        @include margin-left(25px);
       }
     }
   }


### PR DESCRIPTION
I used layout-2col and it worked pretty well.
I also updated the component according to the latest designs and removed the extra decorations from the numbers.
I moved the `promoted-box` markup to it's own component too.

Fix #14
Fix #15 