### PR TITLE
Fix eslint options. Add .eslintignore file.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,9 @@
+# copy of the .gitignore` file
+# Project dependencies
+.cache
+node_modules
+yarn-error.log
+
+# Build directory
+/public
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "./node_modules/.bin/eslint --fix --ignore-path .gitignore .",
+    "format": "eslint --fix ./src/**/**/*.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
In order eslint to run I had to either add `.` or `./src/` as path or to add one more depth of `**` at the path.
I do not understand why `./src/**/*.js` does not work,but `./src/**/**/*.js` does.
