### PR TITLE
Fixes #198.

### DIFF
--- a/src/components/base-styles/base/root/_root.scss
+++ b/src/components/base-styles/base/root/_root.scss
@@ -34,4 +34,5 @@ body {
   margin: 0;
   color: color(text);
   background-color: color(text-bg);
+  min-height: 100vh;
 }

--- a/src/components/layouts/layout-base/layout-base.js
+++ b/src/components/layouts/layout-base/layout-base.js
@@ -59,15 +59,15 @@ const Basic = ({ children }) => {
                 <html lang="en" />
               </Helmet>
               <SkipLink />
-              <div>
-                <Header />
+              <Header />
+              <div className="layout-base__wrapper">
+                <div id="content" className="layout-base">
+                  {children}
+                </div>
+                <footer className="layout-base__bottom">
+                  <Footer />
+                </footer>
               </div>
-              <div id="content" className="layout-base">
-                {children}
-              </div>
-              <footer>
-                <Footer />
-              </footer>
             </div>
           </AuthWrapper>
         </Provider>

--- a/src/components/layouts/layout-base/layout-base.js
+++ b/src/components/layouts/layout-base/layout-base.js
@@ -59,7 +59,9 @@ const Basic = ({ children }) => {
                 <html lang="en" />
               </Helmet>
               <SkipLink />
-              <Header />
+              <div>
+                <Header />
+              </div>
               <div className="layout-base__wrapper">
                 <div id="content" className="layout-base">
                   {children}

--- a/src/components/layouts/layout-base/layout-base.scss
+++ b/src/components/layouts/layout-base/layout-base.scss
@@ -10,9 +10,22 @@
   padding-bottom: 60px;
   overflow: hidden;
   position: relative;
+  width: 100%;
 
   @include breakpoint($tablet) {
     padding-top: 190px;
     padding-bottom: 100px;
+  }
+
+  &__wrapper {
+    min-height: 100vh;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  &__bottom {
+    margin-top: auto;
+    width: 100%;
   }
 }


### PR DESCRIPTION
When page content is smaller that screen height, footer stays at the bottom of the page.