### PR TITLE
Move token handling at auth wrapper

### DIFF
--- a/src/components/layouts/auth-wrapper/auth-wrapper.js
+++ b/src/components/layouts/auth-wrapper/auth-wrapper.js
@@ -76,7 +76,12 @@ class AuthWrapper extends React.PureComponent {
   };
 
   componentDidMount() {
-    let { token } = parse(this.props.location.search);
+    let token =
+      parse(this.props.location.search) &&
+      parse(this.props.location.search).token
+        ? parse(this.props.location.search).token
+        : undefined;
+
     if (token) {
       // eslint-disable-next-line no-undef
       localStorage.setItem('token', token);

--- a/src/components/layouts/auth-wrapper/auth-wrapper.js
+++ b/src/components/layouts/auth-wrapper/auth-wrapper.js
@@ -32,13 +32,7 @@ export const LoginLink = props => {
       className={classes}
       href={`${BACKEND_URL}/oidc/login`}
       onClick={() => {
-        if (window) {
-          const url = window.location;
-          let curentUrl = `${url.pathname}/${url.search}`.replace("//", "/");
-
-          // eslint-disable-next-line no-undef
-          localStorage.setItem("last-visited", curentUrl);
-        }
+        saveCurrentLocation();
       }}
     >
       {label}
@@ -65,6 +59,17 @@ export const LogoutLink = props => {
       {label}
     </button>
   );
+};
+
+// stores the current url to the localStorage under the "last-visited" key
+const saveCurrentLocation = () => {
+  if (window) {
+    const url = window.location;
+    let curentUrl = `${url.pathname}/${url.search}`.replace("//", "/");
+
+    // eslint-disable-next-line no-undef
+    localStorage.setItem("last-visited", curentUrl);
+  }
 };
 
 // source

--- a/src/components/layouts/auth-wrapper/auth-wrapper.js
+++ b/src/components/layouts/auth-wrapper/auth-wrapper.js
@@ -6,29 +6,41 @@ It is based the Provider pattern and uses redux for it's implementation.
 - listens the `authReducer` for the logout event.
 */
 
-import React from 'react';
-import { Query } from 'react-apollo';
-import { navigate } from 'gatsby';
-import { parse } from 'query-string';
-import gql from 'graphql-tag';
-import { actionLogin, actionLogout } from './../../../actions/userActions';
+import React from "react";
+import { Query } from "react-apollo";
+import { navigate } from "gatsby";
+import { parse } from "query-string";
+import gql from "graphql-tag";
+import { actionLogin, actionLogout } from "./../../../actions/userActions";
 import {
   requestLogout,
   resetActionLogout
-} from './../../../actions/authActions';
+} from "./../../../actions/authActions";
 
-import { connect } from 'react-redux';
+import { connect } from "react-redux";
 
-import store from './../../../store';
-import { BACKEND_URL } from './../../../settings';
+import store from "./../../../store";
+import { BACKEND_URL } from "./../../../settings";
 
 // a login button component.
 export const LoginLink = props => {
-  const classes = props.className || '';
-  const label = props.label ? props.label : 'Login';
+  const classes = props.className || "";
+  const label = props.label ? props.label : "Login";
 
   return (
-    <a className={classes} href={`${BACKEND_URL}/oidc/login`}>
+    <a
+      className={classes}
+      href={`${BACKEND_URL}/oidc/login`}
+      onClick={() => {
+        if (window) {
+          const url = window.location;
+          let curentUrl = `${url.pathname}/${url.search}`.replace("//", "/");
+
+          // eslint-disable-next-line no-undef
+          localStorage.setItem("last-visited", curentUrl);
+        }
+      }}
+    >
       {label}
     </a>
   );
@@ -36,8 +48,8 @@ export const LoginLink = props => {
 
 // a logout button component.
 export const LogoutLink = props => {
-  const classes = props.className || '';
-  const label = props.label ? props.label : 'Logout';
+  const classes = props.className || "";
+  const label = props.label ? props.label : "Logout";
 
   const logout = () => {
     store.dispatch(requestLogout());
@@ -84,8 +96,17 @@ class AuthWrapper extends React.PureComponent {
 
     if (token) {
       // eslint-disable-next-line no-undef
-      localStorage.setItem('token', token);
-      navigate('/');
+      localStorage.setItem("token", token);
+
+      // eslint-disable-next-line no-undef
+      const lastUrlBeforeLogin = window.localStorage.getItem("last-visited");
+      if (lastUrlBeforeLogin) {
+        // eslint-disable-next-line no-undef
+        localStorage.removeItem("last-visited");
+        navigate(`/${lastUrlBeforeLogin}`);
+      } else {
+        navigate("/");
+      }
     }
   }
 
@@ -124,7 +145,7 @@ class AuthWrapper extends React.PureComponent {
                   } else {
                     //TODO: Show error to user
                     // eslint-disable-next-line no-console
-                    console.error('Failed to logout');
+                    console.error("Failed to logout");
                   }
                 });
               };

--- a/src/components/layouts/auth-wrapper/auth-wrapper.js
+++ b/src/components/layouts/auth-wrapper/auth-wrapper.js
@@ -93,7 +93,7 @@ class AuthWrapper extends React.PureComponent {
   };
 
   componentDidMount() {
-    let token =
+    const { token } = (parse(this.props.location.search) || {})
       parse(this.props.location.search) &&
       parse(this.props.location.search).token
         ? parse(this.props.location.search).token

--- a/src/components/layouts/auth-wrapper/auth-wrapper.js
+++ b/src/components/layouts/auth-wrapper/auth-wrapper.js
@@ -8,6 +8,8 @@ It is based the Provider pattern and uses redux for it's implementation.
 
 import React from 'react';
 import { Query } from 'react-apollo';
+import { navigate } from 'gatsby';
+import { parse } from 'query-string';
 import gql from 'graphql-tag';
 import { actionLogin, actionLogout } from './../../../actions/userActions';
 import {
@@ -72,6 +74,15 @@ class AuthWrapper extends React.PureComponent {
     loadingState: false,
     shouldLogout: false
   };
+
+  componentDidMount() {
+    let { token } = parse(this.props.location.search);
+    if (token) {
+      // eslint-disable-next-line no-undef
+      localStorage.setItem('token', token);
+      navigate('/');
+    }
+  }
 
   componentDidUpdate(prevPros) {
     if (prevPros.auth.logout === false && this.props.auth.logout === true) {

--- a/src/components/layouts/layout-base/layout-base.js
+++ b/src/components/layouts/layout-base/layout-base.js
@@ -42,7 +42,7 @@ const httpLink = new HttpLink({
   // credentials: 'same-origin'
 });
 
-const Basic = ({ children }) => {
+const Basic = ({ location, children }) => {
   const client = new ApolloClient({
     link: authLink.concat(httpLink),
     cache: new InMemoryCache()
@@ -52,7 +52,7 @@ const Basic = ({ children }) => {
     <React.StrictMode>
       <ApolloProvider client={client}>
         <Provider store={store}>
-          <AuthWrapper>
+          <AuthWrapper location={location}>
             <div>
               <Helmet meta={metadata} link={link}>
                 <title>{GatsbyConfig.siteMetadata.title}</title>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -8,8 +8,8 @@ import LayoutContained from './../components/layouts/layout-contained/layout-con
 
 import GatsbyConfig from './../../gatsby-config';
 
-const NotFoundPage = () => (
-  <BasicLayout>
+const NotFoundPage = props => (
+  <BasicLayout location={props.location}>
     <Helmet>
       <title>
         {['NOT FOUND', '|', GatsbyConfig.siteMetadata.title].join(' ')}

--- a/src/pages/about-us.js
+++ b/src/pages/about-us.js
@@ -19,7 +19,7 @@ import './../components/pages-styles/about-us.scss';
 
 const About = props => {
   return (
-    <BasicLayout>
+    <BasicLayout location={props.location}>
       <Helmet>
         <title>
           {['About', '|', GatsbyConfig.siteMetadata.title].join(' ')}

--- a/src/pages/clubs/index.js
+++ b/src/pages/clubs/index.js
@@ -185,7 +185,7 @@ class Clubs extends React.PureComponent {
       );
 
     return (
-      <BasicLayout>
+      <BasicLayout location={this.props.location}>
         <Helmet>
           <title>
             {['Clubs', '|', GatsbyConfig.siteMetadata.title].join(' ')}

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -20,7 +20,7 @@ import ContributeContent from './../components/components/contribute/contribute'
 class Contribute extends React.PureComponent {
   render() {
     return (
-      <BasicLayout>
+      <BasicLayout location={this.props.location}>
         <Helmet>
           <title>
             {['Opportunities', '|', GatsbyConfig.siteMetadata.title].join(' ')}

--- a/src/pages/faq-page.js
+++ b/src/pages/faq-page.js
@@ -14,7 +14,7 @@ import FaqItem from './../components/components/faq-item/faq-item';
 
 const Questions = props => {
   return (
-    <BasicLayout>
+    <BasicLayout location={props.location}>
       <Helmet>
         <title>{['FAQ', '|', GatsbyConfig.siteMetadata.title].join(' ')}</title>
       </Helmet>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,7 +30,7 @@ const IndexPage = props => {
   };
 
   return (
-    <BasicLayout noDistanceTop>
+    <BasicLayout location={props.location} noDistanceTop>
       {/* New section */}
       <LayoutContained>
         <Banner

--- a/src/pages/leaders-corner.js
+++ b/src/pages/leaders-corner.js
@@ -14,7 +14,7 @@ import LeaderCorner from './../components/components/leaders-corner/leaders-corn
 class Contribute extends React.PureComponent {
   render() {
     return (
-      <BasicLayout>
+      <BasicLayout location={this.props.location}>
         <Helmet>
           <title>
             {["Leader's Corner", '|', GatsbyConfig.siteMetadata.title].join(

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,5 +1,4 @@
 // External modules.
-import { parse } from 'query-string';
 import React from 'react';
 import { Helmet } from 'react-helmet';
 
@@ -13,21 +12,9 @@ class Login extends React.PureComponent {
     user: undefined
   };
 
-  componentDidMount = () => {
-    // QUESTION: Can this be moved to auth-wrapper ?
-    //is being reset at /src/actions/authActions::requestLogout()
-    // localStorage item: gotrue.user.token.access_token is a copy of the token
-    let { token } = parse(this.props.location.search);
-    if (token) {
-      // eslint-disable-next-line no-undef
-      localStorage.setItem('token', token);
-      this.props.navigate('/login');
-    }
-  };
-
   render() {
     return (
-      <BasicLayout>
+      <BasicLayout location={this.props.location}>
         <Helmet>
           <title>
             {['Login', '|', GatsbyConfig.siteMetadata.title].join(' ')}

--- a/src/pages/members/index.js
+++ b/src/pages/members/index.js
@@ -140,7 +140,7 @@ class Members extends React.PureComponent {
     const snapshot = this.state;
 
     return (
-      <BasicLayout>
+      <BasicLayout location={this.props.location}>
         <Helmet>
           <title>
             {['Members', '|', GatsbyConfig.siteMetadata.title].join(' ')}

--- a/src/pages/organizations.js
+++ b/src/pages/organizations.js
@@ -30,7 +30,7 @@ const Organizations = props => {
   });
 
   return (
-    <BasicLayout>
+    <BasicLayout location={props.location}>
       <Helmet>
         <title>
           {['Organization', '|', GatsbyConfig.siteMetadata.title].join(' ')}


### PR DESCRIPTION
To persist user location, I added an entry at the `local storage` which is updated when the user clicks at the `auth-wrapper`'s login button and consumed/removed when a `token` is present at the url. 

The parameters of the user are saved at the local storage too. 

I could not update the the #189 from my fork, so I am creating a new Pull request.