### PR TITLE
Changed github logo on member page to be a generic git icon

### DIFF
--- a/src/components/components/member/member.js
+++ b/src/components/components/member/member.js
@@ -394,7 +394,7 @@ class Member extends React.PureComponent {
       <div className="member__text-field--wrapper-with-icon">
         <GitCommit className="member__icon" />
         <TextInput
-          label="Github/Gitlab/Bitbucket Url"
+          label="Git account url (Github/Gitlab/Bitbucket)"
           name="githubUrl"
           onChange={this.handleChange}
           value={snapshot.githubUrl}

--- a/src/components/components/member/member.js
+++ b/src/components/components/member/member.js
@@ -5,7 +5,7 @@ import {
   Calendar,
   Check,
   Feather,
-  GitHub,
+  GitCommit,
   Inbox,
   Link,
   Users,
@@ -392,9 +392,9 @@ class Member extends React.PureComponent {
 
     const github = isEditing ? (
       <div className="member__text-field--wrapper-with-icon">
-        <GitHub className="member__icon" />
+        <GitCommit className="member__icon" />
         <TextInput
-          label="Github Url"
+          label="Github/Gitlab/Bitbucket Url"
           name="githubUrl"
           onChange={this.handleChange}
           value={snapshot.githubUrl}
@@ -404,7 +404,7 @@ class Member extends React.PureComponent {
     ) : (
       snapshot.githubUrl && (
         <a href={snapshot.githubUrl} target="_blank" rel="noopener noreferrer">
-          <GitHub className="member__icon" />
+          <GitCommit className="member__icon" />
           <span className="member__link-content">{snapshot.githubUrl}</span>
         </a>
       )


### PR DESCRIPTION
Related to Issue #287 

Currently, the GitHub icon appears regardless of if the URL is GitHub or Gitlab. The issue asked if we can make the icon change depending on what type of URL is entered. My idea is to instead change the GitHub icon to a generic git icon, so that GitHub, GitLab, Bitbucket are all equal options and the code or UI doesn't need another if/else logic or text box to do things differently depending on what is entered. I think this would keep the code cleaner. 