### PR TITLE
Set height for club card at tablet and desktop only

### DIFF
--- a/src/components/components/club-teaser-list/club-teaser.scss
+++ b/src/components/components/club-teaser-list/club-teaser.scss
@@ -14,7 +14,7 @@
     display: flex;
     width: 100%;
     @include breakpoint($mobile-small) {
-      height: 192px;
+      min-height: 192px;
     }
   }
 

--- a/src/components/components/club-teaser-list/club-teaser.scss
+++ b/src/components/components/club-teaser-list/club-teaser.scss
@@ -13,6 +13,9 @@
     @include padding-bottom(20px);
     display: flex;
     width: 100%;
+    @include breakpoint($mobile-small) {
+      height: 192px;
+    }
   }
 
   &__content-wrapper {


### PR DESCRIPTION
Issue #307 

This sets a height to the club card, at tablet and desktop views (when cards are displayed in rows). To test it, we'll want to add "short description" text (the text between the club name and the club page button). I tested on the live site via inspector, and it looks a little strange. 
![Screenshot_2019-11-01 Clubs Open Source Student Network](https://user-images.githubusercontent.com/3312395/68066574-25095100-fcf7-11e9-8c55-7499f519d2c7.png)
